### PR TITLE
Users route for API gateway

### DIFF
--- a/api_gateway_variables.tfvars
+++ b/api_gateway_variables.tfvars
@@ -1,7 +1,7 @@
 // API Gateway Resource Variables
 
 // API Gateway
-api_gateway_name     = "api_gateway"
+api_gateway_name     = "loaf_api_gateway"
 api_gateway_protocol = "HTTP"
 
 // API Gateway Route

--- a/api_gateway_variables.tfvars
+++ b/api_gateway_variables.tfvars
@@ -1,11 +1,12 @@
 // API Gateway Resource Variables
 
 // API Gateway
-api_gateway_name     = "event_gateway"
+api_gateway_name     = "api_gateway"
 api_gateway_protocol = "HTTP"
 
 // API Gateway Route
 api_gateway_events_route_key = "POST /events"
+api_gateway_users_route_key  = "POST /users"
 
 // API Gateway Integration
 api_gateway_integration_type        = "AWS_PROXY"

--- a/lambda.tf
+++ b/lambda.tf
@@ -43,5 +43,5 @@ resource "aws_lambda_permission" "allow_api" {
   action              = "lambda:InvokeFunction"
   function_name       = aws_lambda_function.events_lambda.function_name
   principal           = "apigateway.amazonaws.com"
-  source_arn          = "${aws_apigatewayv2_api.event_gateway.execution_arn}/*/*/events"
+  source_arn          = "${aws_apigatewayv2_api.api_gateway.execution_arn}/*/*/events"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -62,3 +62,7 @@ variable "api_gateway_passthrough_behavior" {
   description = "api gateway to lambda passthrough behavior"
 }
 
+variable "api_gateway_users_route_key" {
+  type        = string
+  description = "route key for users route in api gateway"
+}


### PR DESCRIPTION
Updates API gateway to include `/users` route where user identification events can be sent. Also renames the resource to be more general.