### PR TITLE
swap HTTP for HTTPS in load balancer

### DIFF
--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -56,8 +56,10 @@ resource "aws_lb" "test" {
 
 resource "aws_lb_listener" "loaf_listener" {
   load_balancer_arn = aws_lb.test.arn
-  port              = "80"
-  protocol          = "HTTP"
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = aws_acm_certificate.certificate.arn
 
   default_action {
     type             = "forward"


### PR DESCRIPTION
This pull request is to add a listener on port 443 to enable the load balancer to handle incoming HTTPS requests.